### PR TITLE
修复chrome下中文输入法输入大段文字被截断或重复的bug

### DIFF
--- a/editor_all.js
+++ b/editor_all.js
@@ -7723,7 +7723,7 @@ UE.plugins['undo'] = function() {
             range.shrinkBoundary();
             browser.ie && (cont = cont.replace(/>&nbsp;</g,'><').replace(/\s*</g,'').replace(/>\s*/g,'>'));
 
-            if(browser.opera || browser.safari){
+            if(browser.opera || browser.safari || browser.chrome){
                 return {
                     senceRange : new sceneRange(range),
                     content : cont,


### PR DESCRIPTION
直接上图，不太好描述：
![Sequence 01](https://f.cloud.github.com/assets/809865/328096/59e5d61e-9b8d-11e2-985b-2bb6aa8f18a8.gif)
