### PR TITLE
锚链接问题修复

### DIFF
--- a/dialogs/link/link.html
+++ b/dialogs/link/link.html
@@ -103,7 +103,7 @@
         }
     };
     $G('href').onblur = function(){
-        if(!hrefStartWith(this.value,["http","/","ftp://"])){
+        if(!hrefStartWith(this.value,["http","/","ftp://","#"])){
             $G("msg").innerHTML = "<span style='color: red'>"+lang.httpPrompt+"</span>";
         }else{
             $G("msg").innerHTML = "";


### PR DESCRIPTION
修复问题：在uEditor中添加了锚点之后，添加a跳转链接的时候，链接地址为#abc的时候，确认之后uEditor会自动加上http://导致链接地址变成http://#abc这样就不能正确链接到相应的锚点abc了。
