### PR TITLE
Patch_fix_deleterow_queryCommandState_return

### DIFF
--- a/_src/plugins/table.cmds.js
+++ b/_src/plugins/table.cmds.js
@@ -381,8 +381,7 @@
     UE.commands["deleterow"] = {
         queryCommandState: function () {
             var tableItems = getTableItemsByRange(this);
-            if (!tableItems.cell) {
-                return -1;
+            return tableItems.cell ? 0 : -1;
             }
         },
         execCommand: function () {
@@ -473,7 +472,7 @@
     UE.commands["deletecol"] = {
         queryCommandState: function () {
             var tableItems = getTableItemsByRange(this);
-            if (!tableItems.cell) return -1;
+            return tableItems.cell ? 0 : -1;
         },
         execCommand: function () {
             var cell = getTableItemsByRange(this).cell,

--- a/_src/plugins/table.cmds.js
+++ b/_src/plugins/table.cmds.js
@@ -382,7 +382,6 @@
         queryCommandState: function () {
             var tableItems = getTableItemsByRange(this);
             return tableItems.cell ? 0 : -1;
-            }
         },
         execCommand: function () {
             var cell = getTableItemsByRange(this).cell,


### PR DESCRIPTION
解决选中表格单元格时右键菜单无法显示“删除当前行”和“删除当前列“
