### PR TITLE
BUGFIX: Translate to lower case before check image extension.

### DIFF
--- a/dialogs/image/image.js
+++ b/dialogs/image/image.js
@@ -449,7 +449,7 @@
                     file.rotation = 0;
 
                     /* 检查文件格式 */
-                    if (acceptExtensions.indexOf(file.ext) == -1) {
+                    if (acceptExtensions.indexOf(file.ext.toLowerCase()) == -1) {
                         showError('not_allow_type');
                         uploader.removeFile(file);
                     }


### PR DESCRIPTION
By default, we can upload an image names "IMG1303.JPG" or "IMG123.jPG".
