### PR TITLE
关于请求保留原标签id号再次诚恳请求

### DIFF
--- a/_src/adapter/editor.js
+++ b/_src/adapter/editor.js
@@ -752,10 +752,6 @@
 
 
                             }
-                            if(holder.id){
-                                newDiv.id = holder.id;
-                                domUtils.removeAttributes(holder,'id');
-                            }
                             holder = newDiv;
                             holder.innerHTML = '';
                         }

--- a/themes/default/_css/editor.css
+++ b/themes/default/_css/editor.css
@@ -75,6 +75,7 @@
     height: 0;
     overflow: hidden;
     border-spacing: 0;
+    margin: 0;
 }
 
 .edui-default .edui-editor-bottomContainer td {
@@ -83,6 +84,7 @@
     line-height: 20px;
     font-size: 12px;
     font-family: Arial, Helvetica, Tahoma, Verdana, Sans-Serif;
+    padding: 0;
 }
 
 .edui-default .edui-editor-wordcount {


### PR DESCRIPTION
谢谢你上次的回复，但是，我还是希望你们保留id号在原有标签上，我不知道你用不用drupal, 我在开发模块中，需要这个id在原有标签上我才能正常被其他函数调用，我不知道你们为什么非要取我标签的id,然后移动到外层，我不知道你们这样做具体是出于什么考虑，但是，我看了CKEditor  , EpicEditor , FCKeditor,  jWYSIWYG,  markItUp,  NicEdit,  openWYSIWYG,  TinyMCE,  Whizzywig,  WYMeditor, YUI editor, 这些所有编辑器，没有一个是移动了我原有标签的id的，所以真的请能不能想一个办法保留我原有标签的id（你能否另外取一个新id名）, 这真的对我们的开发很重要！

我不知道你们能否明白我的意思，我下面试着向你展示下我的开发中实际的情形：

这是你们编辑器移动id号生成的结构：
![image](https://cloud.githubusercontent.com/assets/7891096/3324136/fe76bc6a-f777-11e3-8ff7-4fa2fc11b9f0.png)

上面的textarea本来有id号edit-comment-body-und-0-value，被你们移动了。

然后我js就找不到正确的id号位置了,然后编辑器就消失不见了：

![image](https://cloud.githubusercontent.com/assets/7891096/3324132/c83d6392-f777-11e3-8b76-ca8fc4979486.png)

上面一个js是切换Text format 编辑器格式的js, 就是选择Filtered HTML 还是Full HTML ，还是Plain text的js,
![image](https://cloud.githubusercontent.com/assets/7891096/3324143/1b1692e6-f778-11e3-917e-ca64d6647b23.png)
![image](https://cloud.githubusercontent.com/assets/7891096/3324167/59d685e0-f778-11e3-964e-95627fefb640.png)

我不知道你能否明白我的说明，你也需会告诉我，我可以修改我js的选择器，是的，我尝试那样做了，但是不只这里会有影响，其他地方还有更复杂的原因，总之，我真的希望你们保留原标签的id号，你的一点小改动，就能方便我们大家一大步！谢谢！
