### PR TITLE
Update popup.css

### DIFF
--- a/themes/default/_css/popup.css
+++ b/themes/default/_css/popup.css
@@ -38,7 +38,7 @@
 }
 
 .edui-default .edui-menu .edui-bordereraser {
-    height: 3px;
+    height: 0 !important;
 }
 
 .edui-default .edui-anchor-topleft .edui-bordereraser {


### PR DESCRIPTION
`li` 下拉框出现的时候，会有白色的空白，如果把 `[id*="_bordereraser"]` 的背景色调为黑色，则尤为明显。
见截图：
http://zhoumengkang.github.io/images/nothing/20140625101501.png

http://zhoumengkang.github.io/images/nothing/20140625103254.png
当然有更好解决办法更好，我也觉得我这样解决不太好。
