### PR TITLE
ConfigManager.java line 65 异常信息被吞掉

### DIFF
--- a/jsp/src/com/baidu/ueditor/ConfigManager.java
+++ b/jsp/src/com/baidu/ueditor/ConfigManager.java
@@ -66,6 +66,8 @@ public final class ConfigManager {
 		try {
 			return new ConfigManager(rootPath, contextPath, uri);
 		} catch ( Exception e ) {
+			// 不要吞异常，否则别人调试起来很麻烦
+			e.printStackTrace();
 			return null;
 		}
 		


### PR DESCRIPTION
异常信息不应完全被吞掉。至少打印出来方便调试。
