### PR TITLE
linux下java容器， 比如应用以/xxx结尾，但rootpath并不以xxx结尾导致配置错误。

### DIFF
--- a/jsp/src/com/baidu/ueditor/ConfigManager.java
+++ b/jsp/src/com/baidu/ueditor/ConfigManager.java
@@ -42,7 +42,7 @@ public final class ConfigManager {
 		
 		this.contextPath = contextPath;
 		
-		if ( contextPath.length() > 0 ) {
+		if ( contextPath.length() > 0 && rootPath.endsWith(contextPath)) {
 			this.rootPath = rootPath.substring( 0, rootPath.length() - contextPath.length() );
 		} else {
 			this.rootPath = rootPath;


### PR DESCRIPTION
linux下java容器， 比如应用以/xxx结尾，但rootpath并不以xxx结尾，而是可以通过配置到别的文件夹。

rootpath不以contentPath结尾时会导致bug
