### PR TITLE
建议增加上返回URL参数是增加contextPath

### DIFF
--- a/jsp/src/com/baidu/ueditor/upload/BinaryUploader.java
+++ b/jsp/src/com/baidu/ueditor/upload/BinaryUploader.java
@@ -77,7 +77,13 @@ public class BinaryUploader {
 			is.close();
 
 			if (storageState.isSuccess()) {
-				storageState.putInfo("url", PathFormat.format(savePath));
+				String contextPath = request.getContextPath();
+				if (contextPath.length() > 0) {
+					storageState.putInfo("url", contextPath + PathFormat.format(savePath));
+				} else {
+					storageState.putInfo("url", PathFormat.format(savePath));
+				}
+				//storageState.putInfo("url", PathFormat.format(savePath));
 				storageState.putInfo("type", suffix);
 				storageState.putInfo("original", originFileName + suffix);
 			}


### PR DESCRIPTION
因为现在java项目基本上都会带上项目的目录：如：http://localhost:8080/myproject，
这样的话在本地服务器中测试的时候路径就会少一个：myporject ，从而导致本地上传图片无法显示。
如果发布到正式的环境中，一般 contextPath 是空的，所以不会有什么影响
