### PR TITLE
Uploader.class.php 中编码转换的bug

### DIFF
--- a/php/Uploader.class.php
+++ b/php/Uploader.class.php
@@ -60,8 +60,6 @@ class Uploader
         } else {
             $this->upFile();
         }
-
-        $this->stateMap['ERROR_TYPE_NOT_ALLOWED'] = iconv('unicode', 'utf-8', $this->stateMap['ERROR_TYPE_NOT_ALLOWED']);
     }
 
     /**


### PR DESCRIPTION
类里面的构造函数中 `$this->stateMap['ERROR_TYPE_NOT_ALLOWED'] = iconv('unicode', 'utf-8', $this->stateMap['ERROR_TYPE_NOT_ALLOWED']);`， 使用了 `iconv` 这个方法，将 `unicode` 转换为 `UTF-8`。但是 `unicode` 是个统称，没有这种编码，Unicode 是由微软发起的美国工业新标准的简称，而他们的关系就是 _UTF-8是Unicode的实现方式之一_。所以如果在 `error_reporting(-1);` 这种情况下，会报错的。并且我认为这里面不需要再进行编码转换了，文件内容部本来就是 UTF-8 了。

具体的Unicode和UTF-8的内容可以参考这里：http://www.ruanyifeng.com/blog/2007/10/ascii_unicode_and_utf-8.html
