### PR TITLE
PHP 上传涂鸦中的设置参数bug

### DIFF
--- a/php/action_upload.php
+++ b/php/action_upload.php
@@ -22,7 +22,6 @@ switch (htmlspecialchars($_GET['action'])) {
         $config = array(
             "pathFormat" => $CONFIG['scrawlPathFormat'],
             "maxSize" => $CONFIG['scrawlMaxSize'],
-            "allowFiles" => $CONFIG['scrawlAllowFiles'],
             "oriName" => "scrawl.png"
         );
         $fieldName = $CONFIG['scrawlFieldName'];


### PR DESCRIPTION
由于图片是生成的，所以上传涂鸦没有对上传类型进行检测。同时配置文件`config.json`也没有`scrawlAllowFiles`这个配置选项，上传的方法里面也没有对类型的检测。导致这里会报错

```
Notice: Undefined index: scrawlAllowFiles in /Path/to/ueditor/php/action_upload.php on line 25
```

所以这里去掉这行配置。
