### PR TITLE
Uploader.class.php 拉取远程图片报错处理

### DIFF
--- a/php/Uploader.class.php
+++ b/php/Uploader.class.php
@@ -179,7 +179,7 @@ class Uploader
             return;
         }
         //获取请求头并检测死链
-        $heads = get_headers($imgUrl, 1);
+        $heads = @get_headers($imgUrl, 1);
         if (!(stristr($heads[0], "200") && stristr($heads[0], "OK"))) {
             $this->stateInfo = $this->getStateInfo("ERROR_DEAD_LINK");
             return;


### PR DESCRIPTION
`get_headers` 方法获取头信息的时候可能会报错，需要添加@来避免warning错误。

参考：http://php.net/manual/zh/function.get-headers.php#113741
