### PR TITLE
simpleupload didn't fire *contentChange* event

### DIFF
--- a/_src/plugins/simpleupload.js
+++ b/_src/plugins/simpleupload.js
@@ -74,6 +74,7 @@ UE.plugin.register('simpleupload', function (){
                             loader.setAttribute('_src', link);
                             loader.setAttribute('alt', json.original || '');
                             loader.removeAttribute('id');
+                            me.fireEvent('contentChange');
                         } else {
                             showErrorLoader && showErrorLoader(json.state);
                         }

--- a/_src/plugins/simpleupload.js
+++ b/_src/plugins/simpleupload.js
@@ -74,7 +74,7 @@ UE.plugin.register('simpleupload', function (){
                             loader.setAttribute('_src', link);
                             loader.setAttribute('alt', json.original || '');
                             loader.removeAttribute('id');
-                            me.fireEvent('contentChange');
+                            me.fireEvent('contentchange');
                         } else {
                             showErrorLoader && showErrorLoader(json.state);
                         }


### PR DESCRIPTION
simpleupload didn't trigger the _contentChange_ event after the image upload success.
When I use ueditor with angular, I listen to the _contentChange_ event to binding  data between editor and model.  When user upload an image, and then just save the model, the model only keep the placeholder image not the server response one.
