### PR TITLE
处理中文双引号不能正常转义 _src/core/utils.js

### DIFF
--- a/_src/core/utils.js
+++ b/_src/core/utils.js
@@ -445,7 +445,7 @@ var utils = UE.utils = {
     },
 
     /**
-     * 将str中的html符号转义,将转义“'，&，<，"，>”五个字符
+     * 将str中的html符号转义,将转义“'，&，<，"，>，”，“”七个字符
      * @method unhtml
      * @param { String } str 需要转义的字符串
      * @return { String } 转义后的字符串
@@ -459,7 +459,7 @@ var utils = UE.utils = {
      * ```
      */
     unhtml:function (str, reg) {
-        return str ? str.replace(reg || /[&<">'](?:(amp|lt|quot|gt|#39|nbsp|#\d+);)?/g, function (a, b) {
+        return str ? str.replace(reg || /[&<">'](?:(amp|lt|ldquo|rdquo|quot|gt|#39|nbsp|#\d+);)?/g, function (a, b) {
             if (b) {
                 return a;
             } else {
@@ -467,6 +467,8 @@ var utils = UE.utils = {
                     '<':'&lt;',
                     '&':'&amp;',
                     '"':'&quot;',
+                     '“':'&ldquo;',
+                    '”':'&rdquo;',
                     '>':'&gt;',
                     "'":'&#39;'
                 }[a]
@@ -492,11 +494,13 @@ var utils = UE.utils = {
      * ```
      */
     html:function (str) {
-        return str ? str.replace(/&((g|l|quo)t|amp|#39|nbsp);/g, function (m) {
+        return str ? str.replace(/&((g|l|quo|ldquo|rdquo)t|amp|#39|nbsp);/g, function (m) {
             return {
                 '&lt;':'<',
                 '&amp;':'&',
                 '&quot;':'"',
+                '&ldquo;':'“',
+                '&rdquo;':'”',  
                 '&gt;':'>',
                 '&#39;':"'",
                 '&nbsp;':' '


### PR DESCRIPTION
处理中文双引号转义问题，如： &ldquo;测试&rdquo;  =>  &amp;ldquo;测试&amp;rdquo;

在 unhtml 与 html 函数中添加中文双引号转义字符
