### PR TITLE
fixed IE10,11下格式刷bug

### DIFF
--- a/_src/plugins/formatmatch.js
+++ b/_src/plugins/formatmatch.js
@@ -103,7 +103,7 @@ UE.plugins['formatmatch'] = function(){
                 return;
             }
 
-
+            me.focus();
               
             var range = me.selection.getRange();
             img = range.getClosedNode();


### PR DESCRIPTION
ie10 11下点击格式刷按钮后，富文本文本框内光标不能移动。
