### PR TITLE
修正项目在服务器上部署路径与线上访问路径不一致时，上传插件不能正确加载配置的问题

### DIFF
--- a/jsp/src/com/baidu/ueditor/ActionEnter.java
+++ b/jsp/src/com/baidu/ueditor/ActionEnter.java
@@ -29,7 +29,7 @@ public class ActionEnter {
 		this.rootPath = rootPath;
 		this.actionType = request.getParameter( "action" );
 		this.contextPath = request.getContextPath();
-		this.configManager = ConfigManager.getInstance( this.rootPath, this.contextPath, request.getRequestURI() );
+		this.configManager = ConfigManager.getInstance( this.rootPath, this.contextPath, request.getRequestURI().replace(request.getContextPath(),"") );
 		
 	}
 	

--- a/jsp/src/com/baidu/ueditor/ConfigManager.java
+++ b/jsp/src/com/baidu/ueditor/ConfigManager.java
@@ -42,11 +42,7 @@ public final class ConfigManager {
 		
 		this.contextPath = contextPath;
 		
-		if ( contextPath.length() > 0 ) {
-			this.rootPath = rootPath.substring( 0, rootPath.length() - contextPath.length() );
-		} else {
-			this.rootPath = rootPath;
-		}
+		this.rootPath = rootPath;
 		
 		this.originalPath = this.rootPath + uri;
 		


### PR DESCRIPTION
rootPath来自于application.getRealPath( "/" )（在controller.jsp中），即来自于服务器本地真实路径，而requestUri来自于request中的访问路径，当两者不一致的时候（如本地路径为localProj，而访问路径为pubProj），会因为拼接出的路经（ConfigManager.originalPath的值）不对而无法加载配置文件，因此应该只取request中的相对路径部分，拼接在本地的绝对路径后面，从而得到配置文件的绝对路径
