### PR TITLE
A bug in plugin contextmenu

### DIFF
--- a/_src/plugins/contextmenu.js
+++ b/_src/plugins/contextmenu.js
@@ -11,7 +11,9 @@
 
 UE.plugins['contextmenu'] = function () {
     var me = this;
-    me.setOpt('enableContextMenu',true);
+    
+    me.setOpt('enableContextMenu', me.getOpt('enableContextMenu') || true);
+    
     if(me.getOpt('enableContextMenu') === false){
         return;
     }


### PR DESCRIPTION
Set the value of enableContextMenu first, then get the value, it will
always be true.

So I add a judge to check whether users have set its value, otherwise
its default value is true.
