### PR TITLE
.Net版-多图上传-在线管理：修复服务器返回图片列表不能倒序Bug

### DIFF
--- a/net/App_Code/ListFileHandler.cs
+++ b/net/App_Code/ListFileHandler.cs
@@ -52,9 +52,10 @@ public class ListFileManager : Handler
             var localPath = Server.MapPath(PathToList);
             buildingList.AddRange(Directory.GetFiles(localPath, "*", SearchOption.AllDirectories)
                 .Where(x => SearchExtensions.Contains(Path.GetExtension(x).ToLower()))
+                .Reverse()
                 .Select(x => PathToList + x.Substring(localPath.Length).Replace("\\", "/")));
             Total = buildingList.Count;
-            FileList = buildingList.OrderBy(x => x).Skip(Start).Take(Size).ToArray();
+            FileList = buildingList.Skip(Start).Take(Size).ToArray();
         }
         catch (UnauthorizedAccessException)
         {


### PR DESCRIPTION
Bug产生原因：字符串数组Linq倒序
