### PR TITLE
simpleupload, 支持一次选中多个文件同时上传；  autofloat， 修复toolbar闪烁的情况。 

### DIFF
--- a/_src/plugins/autofloat.js
+++ b/_src/plugins/autofloat.js
@@ -77,7 +77,8 @@ UE.plugins['autofloat'] = function() {
     function updateFloating(){
         var rect3 = getPosition(me.container);
         var offset=me.options.toolbarTopOffset||0;
-        if (rect3.top < 0 && rect3.bottom - toolbarBox.offsetHeight > offset) {
+        var topOffset=me.options.topOffset||0;
+        if (rect3.top < topOffset && rect3.bottom - toolbarBox.offsetHeight > offset) {
             setFloating();
         }else{
             unsetFloating();


### PR DESCRIPTION
这个与原先的多文件上传不一样。  原先的多文件上传操作比较复杂， 改造成本大。 而这个方式，直接利用input的multiple属性， 同时上传多个文件，操作简单。

服务端的改造点
1.   上传支持多文件。  所有文件上传完成后返回 {"state":"SUCCESS"} 就行。 上传请求中， 额外增加了一个参数 taskId，需要与上传进度关联。 
2.   增加一个方法 GET serverUrl?action=query&taskId=xxx，  查询任务的进度。 返回已成功上传的文件， 格式为：{"0": "http://example.com/xxx0.jpg", "2":"http://example.com/xxx2.jpg" },   其中， "0", "2" 表示上传文件数组的下标。 
