### PR TITLE
Update ueditor.config.js

### DIFF
--- a/ueditor.config.js
+++ b/ueditor.config.js
@@ -400,7 +400,7 @@
 			header: [],
 			hr:     [],
 			i:      ['class', 'style'],
-			img:    ['src', 'alt', 'title', 'width', 'height', 'id', '_src', 'loadingclass', 'class'],
+			img:    ['src', 'alt', 'title', 'width', 'height', 'id', '_src', '_url' 'loadingclass', 'class'],
 			ins:    ['datetime'],
 			li:     ['class', 'style'],
 			mark:   [],
@@ -425,7 +425,10 @@
 			tt:     [],
 			u:      [],
 			ul:     ['class', 'style'],
-			video:  ['autoplay', 'controls', 'loop', 'preload', 'src', 'height', 'width', 'class', 'style']
+			video:  ['autoplay', 'controls', 'loop', 'preload', 'src', 'height', 'width', 'class', 'style'],
+			source: ['src', 'type'],
+			embed: ['type', 'class', 'pluginspage', 'src', 'width', 'height', 'align', 'style', 'wmode', 'play',
+                'loop', 'menu', 'allowscriptaccess', 'allowfullscreen']
 		}
     };
 


### PR DESCRIPTION
xssFilter导致插入视频异常，编辑器在切换源码的过程中过滤掉img的_url属性（用来存储视频url）_src/plugins/video.js里处理的是_url，而不是_src
