### PR TITLE
修正拖放后iframe宽度和fixed状态下的toolbar宽度更新不正确的问题

### DIFF
--- a/_examples/index.html
+++ b/_examples/index.html
@@ -103,6 +103,10 @@
         <a href="setWidthHeightDemo.html" target="_self">设置宽高</a><br/>
         设置宽高的demo页面
     </li>
+	<li>
+        <a href="scaleDemo.html" target="_self">拖放</a><br/>
+        设置拖放的demo页面
+    </li>
     <li>
         <a href="multiEditorWithOneInstance.html" target="_self">多个编辑区使用一个编辑器实例</a><br/>
         多个编辑区使用一个编辑器实例

--- a/_examples/scaleDemo.html
+++ b/_examples/scaleDemo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
+    <title></title>
+    <script type="text/javascript" charset="utf-8" src="../ueditor.config.js"></script>
+    <script type="text/javascript" charset="utf-8" src="editor_api.js"></script>
+</head>
+<body>
+    <h1>UEditor简单功能</h1>
+	<div id="wrap" style="width:310px;height:800px;">
+		<div id="myEditor" >
+			<p>scaleEnabled演示</p>
+		</div>
+	</div>
+    <script type="text/javascript">
+        UE.getEditor('myEditor',{
+            //这里可以选择自己需要的工具按钮名称,此处仅选择如下五个
+            toolbars:[['FullScreen', 'Source', 'Undo', 'Redo','Bold','test']],
+            //focus时自动清空初始化时的内容
+            autoClearinitialContent:true,
+            //关闭字数统计
+            wordCount:false,
+            //关闭elementPath
+            elementPathEnabled:false,
+            //默认的编辑区域高度和宽度
+            initialFrameHeight:300,
+			initialFrameWidth:300,
+			minFrameWidth:300,
+			//开启拖放
+			scaleEnabled:true
+            //更多其他参数，请参考ueditor.config.js中的配置项
+        })
+    </script>
+</body>
+</html>

--- a/_src/adapter/editor.js
+++ b/_src/adapter/editor.js
@@ -553,6 +553,7 @@
             var doc = document,
                 editor = this.editor,
                 editorHolder = editor.container,
+                frameHolder = editor.ui.getDom('iframeholder'),
                 editorDocument = editor.document,
                 toolbarBox = this.getDom("toolbarbox"),
                 bottombar = this.getDom("bottombar"),
@@ -622,6 +623,12 @@
                     isMouseMove = false;
                     editor.ui._actualFrameWidth = scalelayer.offsetWidth - 2;
                     editorHolder.style.width = editor.ui._actualFrameWidth + 'px';
+
+                    if(toolbarBox.style.position == 'fixed')
+                    {
+                        toolbarBox.style.width=editor.ui._actualFrameWidth + 'px';
+                    }
+                    frameHolder.style.width = editor.ui._actualFrameWidth + 'px';
 
                     editor.setHeight(scalelayer.offsetHeight - bottombar.offsetHeight - toolbarBox.offsetHeight - 2,true);
                 }

--- a/_src/core/Editor.js
+++ b/_src/core/Editor.js
@@ -624,7 +624,8 @@
                 this.iframe.parentNode.style.height = height + 'px';
             }
             !notSetHeight && (this.options.minFrameHeight = this.options.initialFrameHeight = height);
-            this.body.style.height = height + 'px';
+            /*iframe中的view设有8px的margin，在重置高度时，body高度应比iframeholder高度小16px，否则会出现滚动条*/
+            this.body.style.height = (height - 16) + 'px';
             !notSetHeight && this.trigger('setHeight')
         },
 


### PR DESCRIPTION
1.iframe的body有8px的margin，重设高度时应该减去16px，以避免显示滚动条。

2.拖放up事件中#_iframeholder的width未更新，导致编辑器边界未同步更新。

3.开启autoFloatEnabled后，在positon:fixed状态下toolbar的width被设为固定值而非css中定义的auto，拖放up事件中toolbar的width未更新导致其宽度显示不正确。
