### PR TITLE
修复simpleupload中上传图片之后，编辑器高度不一一定自动撑开

### DIFF
--- a/_src/plugins/simpleupload.js
+++ b/_src/plugins/simpleupload.js
@@ -70,11 +70,13 @@ UE.plugin.register('simpleupload', function (){
                         if(json.state == 'SUCCESS' && json.url) {
                             loader = me.document.getElementById(loadingId);
                             domUtils.removeClasses(loader, 'loadingclass');
+                            domUtils.on(loader,'load',function(){
+                              me.fireEvent('contentchange');
+                            });
                             loader.setAttribute('src', link);
                             loader.setAttribute('_src', link);
                             loader.setAttribute('alt', json.original || '');
                             loader.removeAttribute('id');
-                            me.fireEvent('contentchange');
                         } else {
                             showErrorLoader && showErrorLoader(json.state);
                         }


### PR DESCRIPTION
问题:  利用simpleupload上传图片之后，编辑器高度不一定能撑开
为什么: 因为触发`contentchange`事件去重新计算高度的时候可能图片还没加载完成
解决方案：监听`load`事件，图片加载后再出发`contentchange`事件
