### PR TITLE
Update ueditor.config.js. 修复由于XSSFilter导致的设置的背景在查看源码和预览时无效

### DIFF
--- a/ueditor.config.js
+++ b/ueditor.config.js
@@ -406,7 +406,7 @@
 			mark:   [],
 			nav:    [],
 			ol:     ['class', 'style'],
-			p:      ['class', 'style'],
+			p:      ['class', 'style', 'data-background'],
 			pre:    ['class', 'style'],
 			s:      [],
 			section:[],


### PR DESCRIPTION
修复由于XSSFilter导致的设置的背景在查看源码和预览时无效，尤其是查看源码回到正常状态会使设置的背景消失的bug。在XSSFilter的whitList中为```<p>```标签添加```data-background```规则。
ueditor将设置的背景信息存放在一个空的```<p>```标签的```data-background```属性上，XSSFilter过滤了这个属性，所以导致背景无效。