### PR TITLE
解决执行 grunt defalut 命令时抛出错误 TypeError: Cannot read property '1' of null

### DIFF
--- a/ueditor.parse.js
+++ b/ueditor.parse.js
@@ -1,12 +1,12 @@
 (function() {
   var paths = [
-    "parse.js",
-    "insertcode.js",
-    "table.js",
-    "charts.js",
-    "background.js",
-    "list.js",
-    "video.js"
+    'parse.js',
+    'insertcode.js',
+    'table.js',
+    'charts.js',
+    'background.js',
+    'list.js',
+    'video.js'
   ];
 
   function getUEBasePath(docUrl, confUrl) {


### PR DESCRIPTION
clone下来以后grunt default会抛出错误