### PR TITLE
fix bug

### DIFF
--- a/_src/plugins/catchremoteimage.js
+++ b/_src/plugins/catchremoteimage.js
@@ -118,7 +118,7 @@ UE.plugins["catchremoteimage"] = function() {
                 domUtils.removeClasses( ci, "loadingclass" );
                 domUtils.setAttributes(ci, {
                     "src": failIMG,
-                    "_src": cj.source,
+                    "_src": failIMG,
                     "data-catchResult":"img_catchFail" // 添加catch失败标记
                 });
                 catchFailList.push(ci);


### PR DESCRIPTION
抓取远程图片失败后 _src 应是failIMG , 不然会影响getContent()输出的值