### PR TITLE
修复：当需要本地化图片带了GET参数时，无法正常获得文件后缀的bug

### DIFF
--- a/php/Uploader.class.php
+++ b/php/Uploader.class.php
@@ -186,7 +186,7 @@ class Uploader
         }
         //格式验证(扩展名验证和Content-Type验证)
         $fileType    = strtolower(strrchr($imgUrl, '.'));
-        $fileTypeArr = explode('?',$fileType);
+        $fileTypeArr = explode('?', $fileType);
         if (!in_array($fileTypeArr[0], $this->config['allowFiles']) || !isset($heads['Content-Type']) || !stristr($heads['Content-Type'], "image")) {
             $this->stateInfo = $this->getStateInfo("ERROR_HTTP_CONTENTTYPE");
             return;

--- a/php/Uploader.class.php
+++ b/php/Uploader.class.php
@@ -186,7 +186,7 @@ class Uploader
         }
         //格式验证(扩展名验证和Content-Type验证)
         $fileType    = strtolower(strrchr($imgUrl, '.'));
-	$fileTypeArr = explode('?',$fileType);
+        $fileTypeArr = explode('?',$fileType);
         if (!in_array($fileTypeArr[0], $this->config['allowFiles']) || !isset($heads['Content-Type']) || !stristr($heads['Content-Type'], "image")) {
             $this->stateInfo = $this->getStateInfo("ERROR_HTTP_CONTENTTYPE");
             return;

--- a/php/Uploader.class.php
+++ b/php/Uploader.class.php
@@ -185,8 +185,9 @@ class Uploader
             return;
         }
         //格式验证(扩展名验证和Content-Type验证)
-        $fileType = strtolower(strrchr($imgUrl, '.'));
-        if (!in_array($fileType, $this->config['allowFiles']) || !isset($heads['Content-Type']) || !stristr($heads['Content-Type'], "image")) {
+        $fileType    = strtolower(strrchr($imgUrl, '.'));
+	$fileTypeArr = explode('?',$fileType);
+        if (!in_array($fileTypeArr[0], $this->config['allowFiles']) || !isset($heads['Content-Type']) || !stristr($heads['Content-Type'], "image")) {
             $this->stateInfo = $this->getStateInfo("ERROR_HTTP_CONTENTTYPE");
             return;
         }


### PR DESCRIPTION
例如：
http://img.xiumi.us/xmi/ua/cq5i/i/a662444d6c6b9fe35c5ca77666209612-sz_18655.png?x-oss-process=image/resize,w_640/auto-orient,1/crop,x_58,y_0,w_435,h_139