### PR TITLE
UEditor嵌套表格出错。

### DIFF
--- a/_examples/completeDemo.html
+++ b/_examples/completeDemo.html
@@ -67,6 +67,12 @@
     ue.addListener('ready',function(){
         this.focus()
     });
+   ue.addListener("showDragPopup",function(type,table){
+//       console.log("over");
+   });
+   ue.addListener("hideDragPopup",function(type,table){
+//       console.log("out");
+   });
     function createEditor(){
         enableBtn();
         UE.getEditor('editor')

--- a/_src/plugins/table.js
+++ b/_src/plugins/table.js
@@ -2702,13 +2702,15 @@ UE.plugins['table'] = function () {
                     replaceTdToTh(rowIndex, cell, tableRow);
                 }
             }
+
             //框选时插入不触发contentchange，需要手动更新索引
             this.update();
-            this.updateWidth(backWidth,defaultValue||{tdPadding:10,tdBorder:1});
+            this.updateWidth(backWidth);
         },
-        updateWidth:function (width,defaultValue) {
+        updateWidth:function (width) {
+            this.table.setAttribute("width","");
             var table = this.table,
-                tmpWidth = getWidth(table) - defaultValue.tdPadding * 2 - defaultValue.tdBorder + width;
+                tmpWidth = getWidth(table);
             if( tmpWidth<table.ownerDocument.body.offsetWidth){
                 table.setAttribute("width",tmpWidth);
                 return;

--- a/_src/plugins/table.js
+++ b/_src/plugins/table.js
@@ -2653,7 +2653,7 @@ UE.plugins['table'] = function () {
                 rowIndex = 0,
                 tableRow, cell,
                 overflow = (this.table.offsetWidth + sourceCell.offsetWidth) > this.table.ownerDocument.body.offsetWidth,
-                backWidth = overflow ? parseInt((this.table.offsetWidth - (this.colsNum + 1) * 20 - (this.colsNum + 1)) / (this.colsNum + 1), 10):(sourceCell.offsetWidth-22);
+                backWidth = overflow ? parseInt((this.table.offsetWidth - (this.colsNum + 1) * 20) / (this.colsNum + 1), 10):(sourceCell.offsetWidth-22);
 
             function replaceTdToTh(rowIndex, cell, tableRow) {
                 if (rowIndex == 0) {
@@ -2779,12 +2779,12 @@ UE.plugins['table'] = function () {
             this.update();
             return results;
         },
-        split:function(cell,rowsNum,colsNum){
+        split2Rows:function(cell,rowsNum){
             var cellInfo = this.getCellInfo(cell),
                 rowSpan = cellInfo.rowSpan,
-                colSpan = cellInfo.colSpan,
                 rowIndex = cellInfo.rowIndex;
-            if(rowSpan>1 && rowsNum%rowSpan!==0 || colSpan>1 && colsNum%colSpan!==0 ) return false;
+            if( rowSpan>1 && rowsNum % rowSpan!==0 && rowSpan%rowsNum!==0 ) return false;
+            var cols = this.getSameStartPosXCells(cell);
 
         },
         getPreviewMergedCellsNum:function (rowIndex, colIndex) {

--- a/_src/plugins/table.js
+++ b/_src/plugins/table.js
@@ -71,10 +71,10 @@ UE.plugins['table'] = function () {
             '.selectTdClass{background-color:#edf5fa !important}' +
                 'table.noBorderTable td,table.noBorderTable th,table.noBorderTable caption{border:1px dashed #ddd !important}' +
                 //插入的表格的默认样式
-                'table{line-height:22px; margin-bottom:10px;border-collapse:collapse;display:table;}' +
-                'td,th{ background:white; padding: 0 10px;border: 1px solid #DDD;line-height: 22px;}' +
-                'caption{border:1px dashed #DDD;border-bottom:0;padding:3px;text-align:center;}' +
-                'th{border-top:2px solid #BBB;background:#F7F7F7;}' +
+                'table{ line-height:22px; margin-bottom:10px;border-collapse:collapse;display:table;}' +
+                'td,th{ background:white; padding: 0 10px;line-height: 22px;}' +
+                'caption{ border:1px dashed #DDD;border-bottom:0;padding:3px;text-align:center;}' +
+                'th{ border-top:2px solid #BBB;background:#F7F7F7;}' +
                 'td p{margin:0;padding:0;}', me.document);
 
         var tableCopyList, isFullCol, isFullRow;
@@ -623,7 +623,7 @@ UE.plugins['table'] = function () {
                     if (isEmptyBlock(td)) {
                         range.setStart(td, 0).setCursor(false, true)
                     } else {
-                        range.selectNodeContents(td).select();
+                        range.selectNodeContents(td).select(true);
                     }
                     state = me.queryCommandState(cmd);
                     value = me.queryCommandValue(cmd);
@@ -1202,7 +1202,7 @@ UE.plugins['table'] = function () {
 
     UE.commands['inserttable'] = {
         queryCommandState:function () {
-            return getTableItemsByRange(this).table ? -1 : 0;
+            return 0;
         },
         execCommand:function (cmd, opt) {
             function createTable(opt, tableWidth, tdWidth) {
@@ -1216,14 +1216,14 @@ UE.plugins['table'] = function () {
                     }
                     html.push('</tr>')
                 }
-                return '<table width="' + tableWidth + '"   ><tbody>' + html.join('') + '</tbody></table>'
+                return '<table border="1" width="' + tableWidth + '"   ><tbody>' + html.join('') + '</tbody></table>'
             }
 
             if (!opt) {
                 opt = utils.extend({}, {
                     numCols:this.options.defaultCols,
                     numRows:this.options.defaultRows,
-                    tdvalign:this.options.tdvalign
+                    9898:this.options.tdvalign
                 })
             }
             var range = this.selection.getRange(),

--- a/_src/plugins/table.js
+++ b/_src/plugins/table.js
@@ -207,7 +207,7 @@ UE.plugins['table'] = function () {
                                 }
                                 cell.innerHTML = cj.innerHTML;
                                 cj.getAttribute('width') && cell.setAttribute('width', cj.getAttribute('width'));
-                                cj.getAttribute('valign') && cell.setAttribute('valign', cj.getAttribute('valign'));
+                                cj.getAttribute('vAlign') && cell.setAttribute('vAlign', cj.getAttribute('vAlign'));
                                 cj.getAttribute('align') && cell.setAttribute('align', cj.getAttribute('align'));
                                 cj.style.cssText && (cell.style.cssText = cj.style.cssText)
                             }
@@ -216,7 +216,7 @@ UE.plugins['table'] = function () {
                                     break;
                                 cj.innerHTML = ci[j].innerHTML;
                                 ci[j].getAttribute('width') && cj.setAttribute('width', ci[j].getAttribute('width'));
-                                ci[j].getAttribute('valign') && cj.setAttribute('valign', ci[j].getAttribute('valign'));
+                                ci[j].getAttribute('vAlign') && cj.setAttribute('vAlign', ci[j].getAttribute('vAlign'));
                                 ci[j].getAttribute('align') && cj.setAttribute('align', ci[j].getAttribute('align'));
                                 ci[j].style.cssText && (cj.style.cssText = ci[j].style.cssText)
                             }
@@ -245,7 +245,7 @@ UE.plugins['table'] = function () {
                                     td.innerHTML = cj.innerHTML;
                                     //todo 定制处理
                                     cj.getAttribute('width') && td.setAttribute('width', cj.getAttribute('width'));
-                                    cj.getAttribute('valign') && td.setAttribute('valign', cj.getAttribute('valign'));
+                                    cj.getAttribute('vAlign') && td.setAttribute('vAlign', cj.getAttribute('vAlign'));
                                     cj.getAttribute('align') && td.setAttribute('align', cj.getAttribute('align'));
                                     cj.style.cssText && (td.style.cssText = cj.style.cssText);
                                     preNode = td;
@@ -1195,7 +1195,7 @@ UE.plugins['table'] = function () {
                 for (var r = 0; r < rowsNum; r++) {
                     html.push('<tr>');
                     for (var c = 0; c < colsNum; c++) {
-                        html.push('<td width="' + tdWidth + '"  valign="' + opt.tdvalign + '" >' + (browser.ie ? domUtils.fillChar : '<br/>') + '</td>')
+                        html.push('<td width="' + tdWidth + '"  vAlign="' + opt.tdvalign + '" >' + (browser.ie ? domUtils.fillChar : '<br/>') + '</td>')
                     }
                     html.push('</tr>')
                 }
@@ -1209,9 +1209,14 @@ UE.plugins['table'] = function () {
                     tdvalign:this.options.tdvalign
                 })
             }
+            var range = this.selection.getRange(),
+                start = range.startContainer,
+                firstParentBlock = domUtils.findParent(start,function(node){
+                    return domUtils.isBlockElm(node);
+                },true);
             var me = this,
                 defaultValue = getDefaultValue(me),
-                tableWidth = getTableWidth(me, needIEHack, defaultValue),
+                tableWidth = getTableWidth(me, needIEHack, defaultValue) - (firstParentBlock ? parseInt(domUtils.getXY(firstParentBlock).x,10):0),
                 tdWidth = Math.floor(tableWidth / opt.numCols - defaultValue.tdPadding * 2 - defaultValue.tdBorder);
             //todo其他属性
             !opt.tdvalign && (opt.tdvalign = me.options.tdvalign);
@@ -1281,11 +1286,11 @@ UE.plugins['table'] = function () {
         queryCommandState:function () {
             return getSelectedArr(this).length ? 0 : -1;
         },
-        execCommand:function (cmd, valign) {
+        execCommand:function (cmd, vAlign) {
             var selectedTds = getSelectedArr(this);
             if (selectedTds.length) {
                 for (var i = 0, ci; ci = selectedTds[i++];) {
-                    ci.setAttribute('vAlign', valign);
+                    ci.setAttribute('vAlign', vAlign);
                 }
             }
         }
@@ -2543,7 +2548,7 @@ UE.plugins['table'] = function () {
                 for (var colIndex = 0; colIndex < numCols; colIndex++) {
                     cell = this.cloneCell(sourceCell,true);
                     this.setCellContent(cell);
-                    cell.setAttribute('valign', cell.getAttribute('valign'));
+                    cell.setAttribute('vAlign', cell.getAttribute('vAlign'));
                     row.appendChild(cell);
                 }
             } else {
@@ -2652,7 +2657,7 @@ UE.plugins['table'] = function () {
                     preCell = tableRow.cells[colIndex == 0 ? colIndex : tableRow.cells.length];
                     cell = this.cloneCell(sourceCell,true); //tableRow.insertCell(colIndex == 0 ? colIndex : tableRow.cells.length);
                     this.setCellContent(cell);
-                    cell.setAttribute('valign', cell.getAttribute('valign'));
+                    cell.setAttribute('vAlign', cell.getAttribute('vAlign'));
                     preCell && cell.setAttribute('width', preCell.getAttribute('width'));
                     if (!colIndex) {
                         tableRow.insertBefore(cell, tableRow.cells[0]);
@@ -2673,7 +2678,7 @@ UE.plugins['table'] = function () {
 
                         cell = this.cloneCell(sourceCell,true);//tableRow.insertCell(cellInfo.cellIndex);
                         this.setCellContent(cell);
-                        cell.setAttribute('valign', cell.getAttribute('valign'));
+                        cell.setAttribute('vAlign', cell.getAttribute('vAlign'));
                         preCell && cell.setAttribute('width', preCell.getAttribute('width'))
                         tableRow.insertBefore(cell, preCell);
                     }
@@ -2745,7 +2750,7 @@ UE.plugins['table'] = function () {
                     tmpCell = tableRow.insertCell(colIndex - this.getPreviewMergedCellsNum(i, colIndex));
                 tmpCell.colSpan = cellInfo.colSpan;
                 this.setCellContent(tmpCell);
-                tmpCell.setAttribute('valign', cell.getAttribute('valign'));
+                tmpCell.setAttribute('vAlign', cell.getAttribute('vAlign'));
                 tmpCell.setAttribute('align', cell.getAttribute('align'));
                 if (cell.style.cssText) {
                     tmpCell.style.cssText = cell.style.cssText;
@@ -2792,7 +2797,7 @@ UE.plugins['table'] = function () {
                     tmpCell = tableRow.insertCell(this.indexTable[rowIndex][j].cellIndex + 1);
                 tmpCell.rowSpan = cellInfo.rowSpan;
                 this.setCellContent(tmpCell);
-                tmpCell.setAttribute('valign',cell.getAttribute('valign'));
+                tmpCell.setAttribute('vAlign',cell.getAttribute('vAlign'));
                 tmpCell.setAttribute('align',cell.getAttribute('align'));
                 tmpCell.setAttribute('width',backWidth);
                 if (cell.style.cssText) {
@@ -2802,7 +2807,7 @@ UE.plugins['table'] = function () {
                 if (cell.tagName == 'TH') {
                     var th = cell.ownerDocument.createElement('th');
                     th.appendChild(tmpCell.firstChild);
-                    th.setAttribute('valign', cell.getAttribute('valign'));
+                    th.setAttribute('vAlign', cell.getAttribute('vAlign'));
                     th.rowSpan = tmpCell.rowSpan;
                     tableRow.insertBefore(th, tmpCell);
                     domUtils.remove(tmpCell)

--- a/_src/plugins/table.js
+++ b/_src/plugins/table.js
@@ -1239,6 +1239,20 @@ UE.plugins['table'] = function () {
             }
         }
     };
+    UE.commands['insertparagraphaftertable'] = {
+        queryCommandState:function () {
+            return getTableItemsByRange(this).cell ? 0 : -1;
+        },
+        execCommand:function () {
+            var table = getTableItemsByRange(this).table;
+            if (table) {
+                var p = this.document.createElement("p");
+                p.innerHTML = browser.ie ? '&nbsp;' : '<br />';
+                domUtils.insertAfter(table,p);
+                this.selection.getRange().setStart(p, 0).setCursor();
+            }
+        }
+    };
 
     UE.commands['deletetable'] = {
         queryCommandState:function () {
@@ -1281,6 +1295,12 @@ UE.plugins['table'] = function () {
                     ci.setAttribute('align', align);
                 }
             }
+        },
+        queryCommandValue:function(cmd){
+            var selectedTds = getSelectedArr(this);
+            if(selectedTds.length){
+                return selectedTds[0].getAttribute('align');
+            }
         }
     };
     UE.commands['cellvalign'] = {
@@ -1293,6 +1313,12 @@ UE.plugins['table'] = function () {
                 for (var i = 0, ci; ci = selectedTds[i++];) {
                     ci.setAttribute('vAlign', vAlign);
                 }
+            }
+        },
+        queryCommandValue:function(cmd){
+            var selectedTds = getSelectedArr(this);
+            if(selectedTds.length){
+                return selectedTds[0].getAttribute('vAlign');
             }
         }
     };

--- a/_src/plugins/table.js
+++ b/_src/plugins/table.js
@@ -477,7 +477,23 @@ UE.plugins['table'] = function () {
                                     }
                                 }
                             }
-                            h == 'h' && me.execCommand('adaptcolbytext');
+                            if(h == 'h') {
+                                var ut = getUETable(target),
+                                    cells = ut.getSameEndPosCells(target,"x"),
+                                    table = ut.table;
+                                table.removeAttribute("width");
+                                utils.each(cells,function(cell){
+                                    cell.removeAttribute("width");
+                                });
+                                setTimeout(function(){
+                                    var width = cells[0].offsetWidth -20;
+                                    utils.each(cells,function(cell){
+                                        cell.setAttribute("width",width);
+                                    })
+                                    table.setAttribute("width",table.offsetWidth)
+                                })
+
+                            }
                         }
                     }
                 }
@@ -1743,9 +1759,6 @@ UE.plugins['table'] = function () {
             };
         }
     }
-    UE.commands["adaptcolbytext"] = {
-
-    };
 
     UE.commands["adaptbytext"] =
         UE.commands["adaptbywindow"] = {

--- a/_src/plugins/table.js
+++ b/_src/plugins/table.js
@@ -477,7 +477,7 @@ UE.plugins['table'] = function () {
                                     }
                                 }
                             }
-                            h == 'h' && me.execCommand('adaptbytext');
+                            h == 'h' && me.execCommand('adaptcolbytext');
                         }
                     }
                 }
@@ -1743,6 +1743,9 @@ UE.plugins['table'] = function () {
             };
         }
     }
+    UE.commands["adaptcolbytext"] = {
+
+    };
 
     UE.commands["adaptbytext"] =
         UE.commands["adaptbywindow"] = {
@@ -1751,8 +1754,6 @@ UE.plugins['table'] = function () {
             },
             execCommand:function (cmd) {
                 var me = this;
-
-
                 var tableItems = getTableItemsByRange(this),
                     table = tableItems.table,
                     cell = tableItems.cell;

--- a/_src/plugins/table.js
+++ b/_src/plugins/table.js
@@ -1871,7 +1871,8 @@ UE.plugins['table'] = function () {
             function getAverageHeight() {
                 var averageHeight, rowNum, sumHeight = 0,
                     tb = ut.table,
-                    tbAttr = getDefaultValue(me, tb);
+                    tbAttr = getDefaultValue(me, tb),
+                    tdpadding = parseInt(domUtils.getComputedStyle(tb.getElementsByTagName('td')[0], "padding-top"));
 
                 if (ut.isFullCol()) {
                     var captionArr = domUtils.getElementsByTagName(tb, "caption"),
@@ -1902,7 +1903,7 @@ UE.plugins['table'] = function () {
                 if (browser.ie && browser.version < 9) {
                     averageHeight = Math.ceil(sumHeight / rowNum);
                 } else {
-                    averageHeight = Math.ceil(sumHeight / rowNum) - tbAttr.tdBorder * 2;
+                    averageHeight = Math.ceil(sumHeight / rowNum) - tbAttr.tdBorder * 2-tdpadding*2;
                 }
                 return averageHeight;
             }

--- a/_src/plugins/table.js
+++ b/_src/plugins/table.js
@@ -1806,7 +1806,7 @@ UE.plugins['table'] = function () {
         queryCommandState:function () {
             var ut = getUETableBySelected(this);
             if (!ut) return -1;
-            return ut.isFullRow() || ut.isFullCol() ? 0 : -1;
+            return ut.isFullCol()&&ut.cellsRange.beginColIndex!=ut.cellsRange.endColIndex? 0 : -1;
         },
         execCommand:function (cmd) {
             var me = this,
@@ -1859,7 +1859,7 @@ UE.plugins['table'] = function () {
             var ut = getUETableBySelected(this);
             if (!ut) return -1;
             if (ut.selectedTds && /th/ig.test(ut.selectedTds[0].tagName)) return -1;
-            return ut.isFullRow() || ut.isFullCol() ? 0 : -1;
+            return ut.isFullRow()&&ut.cellsRange.beginRowIndex!=ut.cellsRange.endRowIndex? 0 : -1;
         },
         execCommand:function (cmd) {
             var me = this,

--- a/_src/plugins/table.js
+++ b/_src/plugins/table.js
@@ -36,6 +36,7 @@ UE.plugins['table'] = function () {
         'cursorpath':me.options.UEDITOR_HOME_URL + "themes/default/images/cursor_",
         'tableDragable':true
     });
+    me.getUETable = getUETable;
     var commands = {
         'deletetable':1,
         'inserttable':1,

--- a/_src/plugins/table.js
+++ b/_src/plugins/table.js
@@ -387,7 +387,7 @@ UE.plugins['table'] = function () {
                 table.onmouseover = function () {
                     if (!overFlag) {
                         overFlag = true;
-                        me.options.tableDragable && me.fireEvent("showDragPopup");
+                        me.options.tableDragable && me.fireEvent("showDragPopup",table);
                     }
                 };
                 table.onmouseout = function (evt) {
@@ -397,7 +397,7 @@ UE.plugins['table'] = function () {
                         y = mousePos.y,
                         p = domUtils.getXY(table);
                     if (x <= p.x || x >= (p.x + table.offsetWidth) || y <= p.y || y >= (p.y + table.offsetHeight)) {
-                        me.options.tableDragable && me.fireEvent("hideDragPopup");
+                        me.options.tableDragable && me.fireEvent("hideDragPopup",table);
                         overFlag = false;
                     }
                     toggleDragableState(me, false, "", null);
@@ -2652,7 +2652,8 @@ UE.plugins['table'] = function () {
             var rowsNum = this.rowsNum,
                 rowIndex = 0,
                 tableRow, cell,
-                backWidth = parseInt((this.table.offsetWidth - (this.colsNum + 1) * 20 - (this.colsNum + 1)) / (this.colsNum + 1), 10);
+                overflow = (this.table.offsetWidth + sourceCell.offsetWidth) > this.table.ownerDocument.body.offsetWidth,
+                backWidth = overflow ? parseInt((this.table.offsetWidth - (this.colsNum + 1) * 20 - (this.colsNum + 1)) / (this.colsNum + 1), 10):(sourceCell.offsetWidth-22);
 
             function replaceTdToTh(rowIndex, cell, tableRow) {
                 if (rowIndex == 0) {

--- a/_src/plugins/table.js
+++ b/_src/plugins/table.js
@@ -489,7 +489,7 @@ UE.plugins['table'] = function () {
                                     var width = cells[0].offsetWidth -20;
                                     utils.each(cells,function(cell){
                                         cell.setAttribute("width",width);
-                                    })
+                                    });
                                     table.setAttribute("width",table.offsetWidth)
                                 })
 
@@ -1766,7 +1766,6 @@ UE.plugins['table'] = function () {
                 return getTableItemsByRange(this).table ? 0 : -1
             },
             execCommand:function (cmd) {
-                var me = this;
                 var tableItems = getTableItemsByRange(this),
                     table = tableItems.table,
                     cell = tableItems.cell;

--- a/_src/plugins/table.js
+++ b/_src/plugins/table.js
@@ -1730,7 +1730,7 @@ UE.plugins['table'] = function () {
                         table.setAttribute('width', getTableWidth(this,needIEHack,getDefaultValue(this,table)));
                         setTimeout(function(){
                             utils.each(tds,function(td){
-                                td.setAttribute("width",td.offsetWidth);
+                                td.setAttribute("width",td.offsetWidth+"");
                             })
                         },0)
 

--- a/_src/plugins/table.js
+++ b/_src/plugins/table.js
@@ -1723,39 +1723,54 @@ UE.plugins['table'] = function () {
                 return getTableItemsByRange(this).table ? 0 : -1
             },
             execCommand:function (cmd) {
+                var me = this;
+                function resetTdWidth(table){
+
+                    var tds = table.getElementsByTagName("td");
+                    utils.each(tds, function (td) {
+                        td.removeAttribute("width");
+                    });
+                    table.setAttribute('width', getTableWidth(me,needIEHack,getDefaultValue(me,table)));
+                    setTimeout(function(){
+                        utils.each(tds,function(td){
+                            (td.colSpan ==1) && td.setAttribute("width",td.offsetWidth+"");
+                        })
+                    },0)
+                }
+
                 var tableItems = getTableItemsByRange(this),
                     table = tableItems.table,
                     cell = tableItems.cell;
                 if (table) {
                     if (cmd == 'adaptbywindow') {
-                        var tds = table.getElementsByTagName("td");
-                        utils.each(tds, function (td) {
-                            td.removeAttribute("width");
-                        });
-                        table.setAttribute('width', getTableWidth(this,needIEHack,getDefaultValue(this,table)));
-                        setTimeout(function(){
-                            utils.each(tds,function(td){
-                                td.setAttribute("width",td.offsetWidth+"");
-                            })
-                        },0)
-
+                        resetTdWidth(table);
                     } else {
-                        var ut = getUETable(table),
-                            preTds = cell?ut.getSameEndPosCells(cell, "x"):table.getElementsByTagName("td");
-                        if (preTds.length) {
-                            table.style.width = "";
-                            table.removeAttribute("width");
-                            utils.each(preTds, function (td) {
-                                td.removeAttribute("width");
-                            });
-
-                            var defaultValue = getDefaultValue(me, table);
-                            var width = table.offsetWidth,
-                                bodyWidth = me.body.offsetWidth;
-                            if (width > bodyWidth) {
-                                table.setAttribute('width', getTableWidth(me, needIEHack, defaultValue));
+                        if(cell){
+                            var ut = getUETable(table),
+                                preTds = ut.getSameEndPosCells(cell, "x");
+                            if (preTds.length) {
+                                var flag = false;
+                                utils.each(preTds,function(td){
+                                    if(!isEmptyBlock(td)){
+                                        flag = true;
+                                        return false;
+                                    }
+                                });
+                                if(!flag)return;
+                                utils.each(preTds, function (td) {
+                                    (td.colSpan==1) && td.removeAttribute("width");
+                                });
+                                table.style.width = "";
+                                table.removeAttribute("width");
+                                var defaultValue = getDefaultValue(me, table);
+                                var width = table.offsetWidth,
+                                    bodyWidth = me.body.offsetWidth;
+                                if (width > bodyWidth) {
+                                    table.setAttribute('width', getTableWidth(me, needIEHack, defaultValue));
+                                }
                             }
-
+                        }else{
+                            resetTdWidth(table);
                         }
                     }
                 }
@@ -2698,7 +2713,7 @@ UE.plugins['table'] = function () {
             }
             var tds = domUtils.getElementsByTagName(this.table, "td");
             utils.each(tds, function (td) {
-                td.setAttribute("width", width);
+                (td.colSpan==1) && td.setAttribute("width", width);
             })
         },
         deleteCol:function (colIndex) {

--- a/_src/plugins/table.js
+++ b/_src/plugins/table.js
@@ -1947,6 +1947,15 @@ UE.plugins['table'] = function () {
                     domUtils.setAttributes(cell, data);
                 });
             }
+        },
+        queryCommandValue:function(cmd){
+            var selectedTds = getSelectedArr(this);
+            if(selectedTds.length){
+                return {
+                    vAlign:selectedTds[0].getAttribute('vAlign'),
+                    align:selectedTds[0].getAttribute('align')
+                }
+            }
         }
     };
     //表格对齐方式

--- a/_src/plugins/table.js
+++ b/_src/plugins/table.js
@@ -1008,10 +1008,10 @@ UE.plugins['table'] = function () {
                 start = domUtils.findParentByTagName(range.startContainer, ['td', 'th', 'caption'], true);
                 end = domUtils.findParentByTagName(range.endContainer, ['td', 'th', 'caption'], true);
                 if (start !== end) {
-                    me.selection.clearRange()
+                    me.selection && me.selection.clearRange()
                 }
             } else {
-                me.selection.clearRange()
+                me.selection && me.selection.clearRange()
             }
         }
         mousedown = false;

--- a/_src/plugins/table.js
+++ b/_src/plugins/table.js
@@ -1963,17 +1963,22 @@ UE.plugins['table'] = function () {
         queryCommandState:function () {
             return getTableItemsByRange(this).table ? 0 : -1
         },
-        execCommand:function (cmd, color) {
+        execCommand:function (cmd, opt) {
             var rng = this.selection.getRange(),
                 table = domUtils.findParentByTagName(rng.startContainer, 'table');
+
             if (table) {
                 var arr = domUtils.getElementsByTagName(table, "td").concat(
                     domUtils.getElementsByTagName(table, "th"),
                     domUtils.getElementsByTagName(table, "caption")
                 );
-                utils.each(arr, function (node) {
-                    node.style.borderColor = color;
+
+                domUtils.setAttributes(table,{
+                    border:opt.width,
+                    borderColor:opt.color||"#ddd"
                 });
+                if(opt["style"]) table.style.borderStyle = opt["style"];
+
             }
         }
     };

--- a/dialogs/table/edittable.html
+++ b/dialogs/table/edittable.html
@@ -39,6 +39,15 @@
                     <span><var id="lang_color"></var></span>
                     <input type="text" class="tone" id="J_tone" readonly='readonly' />
                 </li>
+                <li>
+                    <span>宽度</span>
+                    <input type="text" class="tone" id="J_width" />
+                </li>
+                <li>
+                    <span>样式</span>
+                    <input type="text" class="tone" id="J_style"  />
+                </li>
+
             </ul>
             <div class="clear"></div>
         </div>
@@ -50,6 +59,7 @@
             </div>
         </div>
     </div>
+    <table ></table>
 </div>
 <script type="text/javascript" src="edittable.js"></script>
 </body>

--- a/dialogs/table/edittable.js
+++ b/dialogs/table/edittable.js
@@ -179,7 +179,7 @@
         } else {
             editor.queryCommandState("deletecaption") != -1 && editor.execCommand("deletecaption");
         }
-        editor.execCommand("edittable", tone.value);
+        editor.execCommand("edittable", {color:tone.value,width:$G("J_width").value,"style":$G("J_style").value});
         autoSizeContent.checked ? adaptByTextTable() : "";
         autoSizePage.checked ? editor.execCommand("adaptbywindow") : "";
 


### PR DESCRIPTION
在HTML模式下输入下列HTML代码进去，返回页面模式，会出现错误的呈现。内层嵌套的表格会消失，外层被嵌套的表格会被分隔成多个单元格。
<table width="660" border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td>1</td>
  </tr>
  <tr>
    <td height="75"><table width="660" border="0" cellspacing="0" cellpadding="0">
      <tr>
        <td>2</td>
        <td>3</td>
      </tr>
      <tr>
        <td>4</td>
        <td>5</td>
      </tr>
    </table></td>
  </tr>
</table>
