### PR TITLE
修复调整单元格对齐方式会导致td中textarea元素丢失的问题

### DIFF
--- a/_src/core/dtd.js
+++ b/_src/core/dtd.js
@@ -256,6 +256,7 @@ var dtd = (dom.dtd = (function() {
       img: 1,
       embed: 1,
       input: 1,
+      textarea: 1,
       link: 1,
       meta: 1,
       param: 1,


### PR DESCRIPTION
修复问题：在关闭xss过滤前提下，当选择多个td（td中含有textarea）并修改单元格对齐方式时，td中的textarea会被清空