### PR TITLE
修复：webkit浏览器里加粗和删除线同时作用于一段文字时，无法直接取消删除线的问题

### DIFF
--- a/_src/core/domUtils.js
+++ b/_src/core/domUtils.js
@@ -1622,14 +1622,18 @@ var domUtils = (dom.domUtils = {
     try {
       var value =
         domUtils.getStyle(element, styleName) ||
-        (window.getComputedStyle
+        browser.webkit && styleName === 'text-decoration'
           ? domUtils
               .getWindow(element)
-              .getComputedStyle(element, "")
-              .getPropertyValue(styleName)
-          : (element.currentStyle || element.style)[
-              utils.cssStyleToDomStyle(styleName)
-            ]);
+              .getComputedStyle(element)['webkitTextDecorationsInEffect']
+          : (window.getComputedStyle
+              ? domUtils
+                  .getWindow(element)
+                  .getComputedStyle(element, "")
+                  .getPropertyValue(styleName)
+              : (element.currentStyle || element.style)[
+                  utils.cssStyleToDomStyle(styleName)
+                ]);
     } catch (e) {
       return "";
     }


### PR DESCRIPTION
webkit浏览器内核对于删除线元素的子节点的判断有特殊的字段处理，如chrome