### PR TITLE
兼容怪异模式下获取scrollTop和scrollLeft

### DIFF
--- a/_src/plugins/fiximgclick.js
+++ b/_src/plugins/fiximgclick.js
@@ -259,14 +259,14 @@ UE.plugins["fiximgclick"] = (function() {
           left:
             iframePos.x +
               imgPos.x -
-              me.editor.document.body.scrollLeft -
+              (me.editor.document.documentElement.scrollLeft|| me.editor.document.body.scrollLeft) -
               editorPos.x -
               parseInt(resizer.style.borderLeftWidth) +
               "px",
           top:
             iframePos.y +
               imgPos.y -
-              me.editor.document.body.scrollTop -
+              (me.editor.document.documentElement.scrollTop || me.editor.document.body.scrollTop) -
               editorPos.y -
               parseInt(resizer.style.borderTopWidth) +
               "px"


### PR DESCRIPTION
在怪异模式下上传图片后，点选上传的图片，图片缩放的覆盖层定位出现盘查。
![wx20180531-174423](https://user-images.githubusercontent.com/12181600/40775300-4c6471f8-64fa-11e8-8e42-16c0bcdd6600.png)
