### PR TITLE
修复某些PHP版本，直接输入10000000000报错参数类型错误

### DIFF
--- a/php/Uploader.class.php
+++ b/php/Uploader.class.php
@@ -290,7 +290,7 @@ class Uploader
         $format = str_replace("{filename}", $oriName, $format);
 
         //替换随机字符串
-        $randNum = rand(1, 10000000000) . rand(1, 10000000000);
+        $randNum = rand(1, PHP_INT_MAX) . rand(1, PHP_INT_MAX);
         if (preg_match("/\{rand\:([\d]*)\}/i", $format, $matches)) {
             $format = preg_replace("/\{rand\:[\d]*\}/i", substr($randNum, 0, $matches[1]), $format);
         }


### PR DESCRIPTION
## 系统相关
### PHP_VERSION
7.0.12
### OS
Windows x64

## 测试代码
```php
<?php
var_dump([
    '10000000000' => 10000000000,
    'PHP_INT_MAX' => PHP_INT_MAX,
    'PHP_VERSION' => PHP_VERSION
]);
exit;
```

## 结果输出
```
array (size=3)
  '10000000000' => float 10000000000
  'PHP_INT_MAX' => int 2147483647
  'PHP_VERSION' => string '7.0.12' (length=6)
```

10000000000 已超过 当前环境下 PHP 最大整形
