### PR TITLE
fix: 缩放图片时，鼠标mouseUp后图片还是在缩放

### DIFF
--- a/_src/plugins/fiximgclick.js
+++ b/_src/plugins/fiximgclick.js
@@ -89,7 +89,8 @@ UE.plugins["fiximgclick"] = (function() {
         me.isDraging = false;
       },
       _eventHandler: function(e) {
-        var me = this;
+        var me = this,
+            pressMouseLeft = e.buttons === undefined ? e.which === 1 : e.buttons === 1;
         switch (e.type) {
           case "mousedown":
             var hand = e.target || e.srcElement,
@@ -105,7 +106,7 @@ UE.plugins["fiximgclick"] = (function() {
             }
             break;
           case "mousemove":
-            if (me.dragId != -1) {
+            if (me.dragId != -1 && pressMouseLeft) {
               me.updateContainerStyle(me.dragId, {
                 x: e.clientX - me.prePos.x,
                 y: e.clientY - me.prePos.y


### PR DESCRIPTION
缩放图片时，点击拖拽的按钮迅速移动出编辑框外，偶现鼠标 mouseUp 没有触发事件，图片还是会跟着缩放