### PR TITLE
BugFix: X(utils.extend2)函数合并到目标对象上，造成$nonBodyContent值错误。

### DIFF
--- a/_src/core/dtd.js
+++ b/_src/core/dtd.js
@@ -162,7 +162,7 @@ var dtd = (dom.dtd = (function() {
     Q = _({ li: 1, ol: 1, ul: 1 }),
     R = _({ style: 1, script: 1 }),
     S = _({ base: 1, link: 1, meta: 1, title: 1 }),
-    T = X(S, R),
+    T = X({}, S, R),
     U = _({ head: 1, body: 1 }),
     V = _({ html: 1 });
 
@@ -217,7 +217,7 @@ var dtd = (dom.dtd = (function() {
     // $ 表示自定的属性
 
     // body外的元素列表.
-    $nonBodyContent: X(V, U, S),
+    $nonBodyContent: X({}, V, U, S),
 
     //块结构元素列表
     $block: block,


### PR DESCRIPTION
BugFix: X(utils.extend2)函数合并到目标对象上，造成$nonBodyContent值错误。设置合并目标对象为一个空对象，避免数据污染。